### PR TITLE
Skip unknown fields in the message

### DIFF
--- a/aper_test.go
+++ b/aper_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/omec-project/aper/logger"
+	"github.com/stretchr/testify/assert"
 )
 
 var perTestTraceLevel = 2
@@ -936,6 +937,10 @@ func TestOpenType(t *testing.T) {
 		perTestTrace(1, "[FAIL]\n")
 		t.Errorf("TEST %d is FAILED", i+1)
 	}
+	var x openTypeTest1
+	err := Unmarshal([]byte{0x11, 0x08, 0x06, 0x88, 0xFE, 0x06, 0xEC, 0x00, 0x05, 0xD8}, &x)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, x.Value.Present)
 }
 
 // BOOLEAN TEST

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,11 @@ go 1.21
 require (
 	github.com/antonfisher/nested-logrus-formatter v1.3.1
 	github.com/sirupsen/logrus v1.8.1
+	github.com/stretchr/testify v1.2.2
 )
 
-require golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 // indirect
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 // indirect
+)

--- a/marshal.go
+++ b/marshal.go
@@ -693,7 +693,7 @@ func (pd *perRawBitData) makeField(v reflect.Value, params fieldParameters) erro
 		// pass tag for optional
 		for i := 0; i < structType.NumField(); i++ {
 			if structType.Field(i).PkgPath != "" {
-				return fmt.Errorf("struct contains unexported fields : " + structType.Field(i).PkgPath)
+				return fmt.Errorf("struct contains unexported fields : %s", structType.Field(i).PkgPath)
 			}
 			tempParams := parseFieldParameters(structType.Field(i).Tag.Get("aper"))
 			if sequenceType {
@@ -794,7 +794,7 @@ func (pd *perRawBitData) makeField(v reflect.Value, params fieldParameters) erro
 			params.sizeUpperBound)
 		return err
 	}
-	return fmt.Errorf("unsupported: " + v.Type().String())
+	return fmt.Errorf("unsupported: %s", v.Type().String())
 }
 
 // Marshal returns the ASN.1 encoding of val.


### PR DESCRIPTION
    **Skip unknown fields in the message**

    Sometimes gNodeb may send some of the AVPs in the ngap messages
    which are not known. Its best to ignore them and move ahead
    with message parsing.